### PR TITLE
fix: vendor in json database from chainsauce and fix i/o performance

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 /.git
 /dist
 .env
+.var

--- a/package-lock.json
+++ b/package-lock.json
@@ -2450,7 +2450,7 @@
     },
     "node_modules/chainsauce": {
       "version": "1.0.19",
-      "resolved": "git+ssh://git@github.com/boudra/chainsauce.git#4a1484ab9724b8fdfb6126e2999ed4319171a6d4",
+      "resolved": "git+ssh://git@github.com/boudra/chainsauce.git#ee7d0f8d050532a1eda10ca2d480e097062629ee",
       "license": "MIT",
       "dependencies": {
         "@types/uuid": "^9.0.4",
@@ -9124,7 +9124,7 @@
       }
     },
     "chainsauce": {
-      "version": "git+ssh://git@github.com/boudra/chainsauce.git#4a1484ab9724b8fdfb6126e2999ed4319171a6d4",
+      "version": "git+ssh://git@github.com/boudra/chainsauce.git#ee7d0f8d050532a1eda10ca2d480e097062629ee",
       "from": "chainsauce@github:boudra/chainsauce#main",
       "requires": {
         "@types/uuid": "^9.0.4",
@@ -9561,6 +9561,11 @@
       "requires": {
         "path-type": "^4.0.0"
       }
+    },
+    "diskstats": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/diskstats/-/diskstats-0.1.0.tgz",
+      "integrity": "sha512-oGkzSh3kQgeYWb5XW6uXk/kepKJP0ui32lSo9mETWDuecNnFCLnzmXvgeQ/YvUwX0lmUek/EMycsVWh5f/x3kA=="
     },
     "doctrine": {
       "version": "3.0.0",

--- a/src/database.ts
+++ b/src/database.ts
@@ -17,6 +17,7 @@ export interface Collection<T extends Document> {
 
 export interface Database {
   collection<T extends Document>(name: string): Collection<T>;
+  flushWrites(): Promise<void>;
 }
 
 export function createChainJsonDatabase(

--- a/src/database/json.test.ts
+++ b/src/database/json.test.ts
@@ -27,7 +27,7 @@ describe("JsonDatabase", () => {
     dbDir = await fs.mkdtemp(path.join(os.tmpdir(), "db-"));
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     setTimeout(() => fs.rm(dbDir, { recursive: true }), 1000);
   });
 

--- a/src/database/json.test.ts
+++ b/src/database/json.test.ts
@@ -1,0 +1,183 @@
+import { describe, beforeEach, test, afterEach, expect } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+import { Document } from "../database.js";
+import { createJsonDatabase } from "./json.js";
+
+type User = Document & {
+  name: string;
+  email: string;
+};
+
+async function readJSON(path: string): Promise<unknown> {
+  const content = await fs.readFile(path, "utf-8");
+  return JSON.parse(content) as unknown;
+}
+
+describe("JsonDatabase", () => {
+  let dbDir: string;
+
+  function createDatabase() {
+    return createJsonDatabase({ dir: dbDir, writeDelay: 0 });
+  }
+
+  beforeEach(async () => {
+    dbDir = await fs.mkdtemp(path.join(os.tmpdir(), "db-"));
+  });
+
+  afterEach(async () => {
+    setTimeout(() => fs.rm(dbDir, { recursive: true }), 1000);
+  });
+
+  test("insert and findById", async () => {
+    const db = createDatabase();
+    const users = db.collection<User>("users1");
+
+    await users.insert({ id: "1", name: "Alice", email: "alice@example.com" });
+    await users.insert({ id: "2", name: "Bob", email: "bob@example.com" });
+
+    const user = await users.findById("1");
+
+    expect(user).toEqual({
+      id: "1",
+      name: "Alice",
+      email: "alice@example.com",
+    });
+  });
+
+  test("parallel insert and findById", async () => {
+    const db = createDatabase();
+    const users = db.collection<User>("users2");
+
+    await users.insert({ id: "1", name: "Alice", email: "alice@example.com" });
+    await users.insert({ id: "2", name: "Bob", email: "bob@example.com" });
+
+    const user = await users.findById("1");
+
+    expect(user).toEqual({
+      id: "1",
+      name: "Alice",
+      email: "alice@example.com",
+    });
+  });
+
+  test("updateById", async () => {
+    const db = createDatabase();
+    const users = db.collection<User>("users3");
+
+    await users.insert({ id: "1", name: "Alice", email: "alice@example.com" });
+
+    const updatedUser = await users.updateById("1", (user) => ({
+      ...user,
+      name: "Alicia",
+    }));
+
+    expect(updatedUser).toEqual({
+      id: "1",
+      name: "Alicia",
+      email: "alice@example.com",
+    });
+  });
+
+  test("upsertById", async () => {
+    const db = createDatabase();
+    const users = db.collection<User>("users4");
+
+    const isNew = await users.upsertById("1", (user) => {
+      expect(user).toBeNull();
+
+      return {
+        id: "1",
+        name: "Alice",
+        email: "alice@example.com",
+      };
+    });
+
+    expect(isNew).toBe(true);
+
+    const isNew2 = await users.upsertById("1", (user) => {
+      expect(user).not.toBeNull();
+
+      return {
+        name: "Alice",
+        email: "alice@example.com",
+      };
+    });
+
+    expect(isNew2).toBe(false);
+
+    const user = await users.findById("1");
+
+    expect(user).toEqual({
+      id: "1",
+      name: "Alice",
+      email: "alice@example.com",
+    });
+  });
+
+  test("all", async () => {
+    const db = createDatabase();
+    const users = db.collection<User>("users5");
+
+    await users.insert({ id: "1", name: "Alice", email: "alice@example.com" });
+    await users.insert({ id: "2", name: "Bob", email: "bob@example.com" });
+
+    const allUsers = await users.all();
+    expect(allUsers).toEqual([
+      { id: "1", name: "Alice", email: "alice@example.com" },
+      { id: "2", name: "Bob", email: "bob@example.com" },
+    ]);
+  });
+
+  test("writes JSON files", async () => {
+    // test write delay code path
+    const db = createJsonDatabase({ dir: dbDir, writeDelay: 200 });
+    const users = db.collection<User>("sub/users6");
+
+    await users.insert({ id: "1", name: "Alice", email: "alice@example.com" });
+
+    // wait for the write delay
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    const dbData = await readJSON(path.join(dbDir, "sub/users6.json"));
+
+    expect(dbData).toEqual([
+      {
+        id: "1",
+        name: "Alice",
+        email: "alice@example.com",
+      },
+    ]);
+  });
+
+  test("concurrent writes", async () => {
+    // test write delay code path
+    const db = createJsonDatabase({ dir: dbDir, writeDelay: 200 });
+    const users = db.collection<User>("sub/users7");
+
+    await Promise.all([
+      users.insert({ id: "1", name: "Alice", email: "alice@example.com" }),
+      users.insert({ id: "2", name: "Bob", email: "bob@example.com" }),
+    ]);
+
+    // wait for the write delay
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    const dbData = await readJSON(path.join(dbDir, "sub/users7.json"));
+
+    expect(dbData).toEqual([
+      {
+        id: "1",
+        name: "Alice",
+        email: "alice@example.com",
+      },
+      {
+        id: "2",
+        name: "Bob",
+        email: "bob@example.com",
+      },
+    ]);
+  });
+});

--- a/src/database/json.test.ts
+++ b/src/database/json.test.ts
@@ -139,7 +139,7 @@ describe("JsonDatabase", () => {
     await users.insert({ id: "1", name: "Alice", email: "alice@example.com" });
 
     // wait for the write delay
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    await db.flushWrites();
 
     const dbData = await readJSON(path.join(dbDir, "sub/users6.json"));
 
@@ -163,7 +163,7 @@ describe("JsonDatabase", () => {
     ]);
 
     // wait for the write delay
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    await db.flushWrites();
 
     const dbData = await readJSON(path.join(dbDir, "sub/users7.json"));
 

--- a/src/database/json.ts
+++ b/src/database/json.ts
@@ -1,0 +1,182 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { debounce } from "throttle-debounce";
+
+import { Collection, Database, Document } from "../database.js";
+
+function buildIndex<T extends Document>(data: T[]): { [key: string]: number } {
+  const index: { [key: string]: number } = {};
+
+  for (let i = 0; i < data.length; i++) {
+    index[data[i].id] = i;
+  }
+
+  return index;
+}
+
+type Index = { [key: string]: number };
+
+async function loadJsonData<T extends Document>(
+  filename: string,
+  decodeJson: (data: string) => unknown = JSON.parse
+): Promise<{ data: T[]; index: Index }> {
+  try {
+    await fs.stat(filename);
+  } catch (err) {
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      "code" in err &&
+      err.code === "ENOENT"
+    ) {
+      // file not found, return empty data
+      return { data: [], index: {} };
+    }
+
+    throw err;
+  }
+
+  const fileContents = await fs.readFile(filename, "utf-8");
+  const data = decodeJson(fileContents) as T[];
+  const index = buildIndex(data);
+
+  return { data, index };
+}
+
+class JsonCollection<T extends Document> implements Collection<T> {
+  private filename: string;
+  private loadingPromise: Promise<{ data: T[]; index: Index }> | null = null;
+  private savingPromise: Promise<void> | null = null;
+  private debouncedSave: ReturnType<typeof debounce>;
+  private encodeJson: (data: unknown) => string;
+  private decodeJson: (data: string) => unknown;
+
+  constructor(filename: string, options: Options) {
+    this.filename = filename;
+    this.encodeJson = options.encodeJson ?? JSON.stringify;
+    this.decodeJson = options.decodeJson ?? JSON.parse;
+    this.debouncedSave = debounce(options.writeDelay ?? 0, () => this.save());
+  }
+
+  private async executeOperation<TReturn>(
+    op: (data: { data: T[]; index: Index }) => TReturn
+  ): Promise<TReturn> {
+    const { data, index } = await this.load();
+    const result = op({ data, index });
+    this.debouncedSave(data);
+    return result;
+  }
+
+  private async load(): Promise<{ data: T[]; index: Index }> {
+    this.debouncedSave.cancel();
+    // Wait for any ongoing save operation to complete
+    if (this.savingPromise !== null) {
+      await this.savingPromise;
+    }
+
+    if (this.loadingPromise !== null) {
+      return this.loadingPromise;
+    }
+
+    this.loadingPromise = loadJsonData(this.filename, this.decodeJson);
+
+    return this.loadingPromise;
+  }
+
+  private async save() {
+    if (this.loadingPromise === null) {
+      throw new Error("Saving without loading first!");
+    }
+
+    const { data } = await this.loadingPromise;
+
+    this.savingPromise = fs
+      .mkdir(path.dirname(this.filename), { recursive: true })
+      .then(() => fs.writeFile(`${this.filename}.write`, this.encodeJson(data)))
+      .then(() => fs.rename(`${this.filename}.write`, this.filename))
+      .finally(() => {
+        this.savingPromise = null;
+        this.loadingPromise = null;
+      });
+
+    return this.savingPromise;
+  }
+
+  async insert(document: T): Promise<T> {
+    if (typeof document !== "object") {
+      throw new Error("Document must be an object");
+    }
+
+    return this.executeOperation(({ data, index }) => {
+      data.push(document);
+      index[document.id] = data.length - 1;
+
+      return document;
+    });
+  }
+
+  async findById(id: string): Promise<T | null> {
+    return this.executeOperation(({ data, index }) => {
+      return data[index[id]] ?? null;
+    });
+  }
+
+  async updateById(id: string, fun: (doc: T) => T): Promise<T | null> {
+    return this.executeOperation(({ data, index }) => {
+      if (index[id] === undefined) {
+        return null;
+      }
+
+      const updatedRecord = fun(data[index[id]]);
+      data[index[id]] = { ...updatedRecord, id: data[index[id]].id };
+
+      return data[index[id]];
+    });
+  }
+
+  // returns true it inserted a new record
+  async upsertById(id: string, fun: (doc: T | null) => T): Promise<boolean> {
+    return this.executeOperation(({ data, index }) => {
+      const isNewDocument = index[id] === undefined;
+
+      if (isNewDocument) {
+        const document = fun(null);
+        data.push(document);
+        index[document.id] = data.length - 1;
+      } else {
+        const updatedRecord = fun(data[index[id]]);
+        data[index[id]] = { ...updatedRecord, id: data[index[id]].id };
+      }
+
+      return isNewDocument;
+    });
+  }
+
+  async all(): Promise<T[]> {
+    return this.executeOperation(({ data }) => {
+      return data;
+    });
+  }
+}
+
+export interface Options {
+  dir: string;
+  writeDelay?: number;
+  encodeJson?: (data: unknown) => string;
+  decodeJson?: (data: string) => unknown;
+}
+
+export function createJsonDatabase(options: Options): Database {
+  const collections: Record<string, Collection<Document>> = {};
+
+  return {
+    collection<T extends Document>(name: string): Collection<T> {
+      if (collections[name] === undefined) {
+        const filename = path.join(options.dir, `${name}.json`);
+        collections[name] = new JsonCollection(filename, options);
+      }
+
+      return collections[name] as Collection<T>;
+    },
+  };
+}

--- a/src/database/json.ts
+++ b/src/database/json.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { debounce } from "throttle-debounce";
+import fastq from "fastq";
 
 import { Collection, Database, Document } from "../database.js";
 
@@ -20,8 +21,10 @@ async function loadJsonData<T extends Document>(
   filename: string,
   decodeJson: (data: string) => unknown = JSON.parse
 ): Promise<{ data: T[]; index: Index }> {
+  let fileContents: string = "[]";
+
   try {
-    await fs.stat(filename);
+    fileContents = await fs.readFile(filename, "utf-8");
   } catch (err) {
     if (
       typeof err === "object" &&
@@ -36,77 +39,163 @@ async function loadJsonData<T extends Document>(
     throw err;
   }
 
-  const fileContents = await fs.readFile(filename, "utf-8");
   const data = decodeJson(fileContents) as T[];
   const index = buildIndex(data);
 
   return { data, index };
 }
 
+type Operation<T> = {
+  type: "query" | "modify";
+  execute: (args: { data: T[]; index: Index }) => unknown;
+};
+
+interface LoadedState<T> {
+  type: "loaded";
+  data: T[];
+  index: Index;
+  isModified: boolean;
+}
+
+interface EmptyState {
+  type: "empty";
+}
+
+interface ReadingFromDiskState<T> {
+  type: "readingFromDisk";
+  promise: Promise<LoadedState<T>>;
+}
+
+interface WritingToDiskState {
+  type: "writingToDisk";
+  promise: Promise<void>;
+}
+
+type State<T> =
+  | EmptyState
+  | LoadedState<T>
+  | ReadingFromDiskState<T>
+  | WritingToDiskState;
+
 class JsonCollection<T extends Document> implements Collection<T> {
   private filename: string;
-  private loadingPromise: Promise<{ data: T[]; index: Index }> | null = null;
-  private savingPromise: Promise<void> | null = null;
-  private debouncedSave: ReturnType<typeof debounce>;
+  private state: State<T> = { type: "empty" };
   private encodeJson: (data: unknown) => string;
   private decodeJson: (data: string) => unknown;
+  private enqueueWrite: (task: () => Promise<void>) => Promise<void>;
+  private queue: fastq.queueAsPromised<Operation<T>>;
 
-  constructor(filename: string, options: Options) {
+  constructor(
+    filename: string,
+    options: {
+      queueWrite: (task: () => Promise<void>) => Promise<void>;
+      writeDelay?: number;
+      encodeJson?: (data: unknown) => string;
+      decodeJson?: (data: string) => unknown;
+    }
+  ) {
     this.filename = filename;
+    this.enqueueWrite = options.queueWrite;
     this.encodeJson = options.encodeJson ?? JSON.stringify;
     this.decodeJson = options.decodeJson ?? JSON.parse;
-    this.debouncedSave = debounce(options.writeDelay ?? 0, () => this.save());
-  }
 
-  private async executeWriteOperation<TReturn>(
-    op: (data: { data: T[]; index: Index }) => TReturn
-  ): Promise<TReturn> {
-    const { data, index } = await this.load();
-    const result = op({ data, index });
-    this.debouncedSave(data);
-    return result;
-  }
+    const scheduleSave = debounce(options.writeDelay ?? 0, () => {
+      void this.enqueueWrite(async () => {
+        if (this.state.type !== "loaded") {
+          return;
+        }
 
-  private async executeReadOperation<TReturn>(
-    op: (data: { data: T[]; index: Index }) => TReturn
-  ): Promise<TReturn> {
-    const { data, index } = await this.load();
-    const result = op({ data, index });
-    return result;
-  }
+        // if we haven't made any changes, don't write to disk
+        if (this.state.isModified === false) {
+          this.state = {
+            type: "empty",
+          };
+          return;
+        }
 
-  private async load(): Promise<{ data: T[]; index: Index }> {
-    this.debouncedSave.cancel({ upcomingOnly: true });
-    // Wait for any ongoing save operation to complete
-    if (this.savingPromise !== null) {
-      await this.savingPromise;
-    }
+        const data = this.state.data;
 
-    if (this.loadingPromise !== null) {
-      return this.loadingPromise;
-    }
+        const promise = fs
+          .mkdir(path.dirname(filename), {
+            recursive: true,
+          })
+          .then(() => fs.writeFile(this.filename, this.encodeJson(data)))
+          .finally(() => {
+            this.state = {
+              type: "empty",
+            };
+          });
 
-    this.loadingPromise = loadJsonData(this.filename, this.decodeJson);
+        this.state = {
+          type: "writingToDisk",
+          promise,
+        };
 
-    return this.loadingPromise;
-  }
-
-  private async save() {
-    if (this.loadingPromise === null) {
-      throw new Error("Saving without loading first!");
-    }
-
-    const { data } = await this.loadingPromise;
-
-    this.savingPromise = fs
-      .mkdir(path.dirname(this.filename), { recursive: true })
-      .then(() => fs.writeFile(this.filename, this.encodeJson(data)))
-      .finally(() => {
-        this.savingPromise = null;
-        this.loadingPromise = null;
+        return promise;
       });
+    });
 
-    return this.savingPromise;
+    this.queue = fastq.promise(async (op) => {
+      switch (op.type) {
+        case "query": {
+          const { data, index } = await this.load();
+          const result = op.execute({ data, index });
+          scheduleSave();
+          return result;
+        }
+        case "modify": {
+          const state = await this.load();
+          const result = op.execute({ data: state.data, index: state.index });
+          state.isModified = true;
+          scheduleSave();
+          return result;
+        }
+      }
+    }, 1);
+  }
+
+  private async load(): Promise<LoadedState<T>> {
+    if (this.state.type === "loaded") {
+      return this.state;
+    } else if (this.state.type === "readingFromDisk") {
+      return this.state.promise;
+    } else if (this.state.type === "empty") {
+      this.state = {
+        type: "readingFromDisk",
+        promise: loadJsonData<T>(this.filename, this.decodeJson).then(
+          (data) => {
+            this.state = {
+              type: "loaded",
+              data: data.data,
+              index: data.index,
+              isModified: false,
+            };
+            return this.state;
+          }
+        ),
+      };
+      return this.state.promise;
+    } else if (this.state.type === "writingToDisk") {
+      await this.state.promise;
+      return this.load();
+    }
+
+    throw new Error("Invalid state");
+  }
+
+  private executeQueryOperation<R>(
+    operation: (args: { data: T[]; index: Index }) => R
+  ): Promise<R> {
+    return this.queue.push({ type: "query", execute: operation }) as Promise<R>;
+  }
+
+  private executeModifyOperation<R>(
+    operation: (args: { data: T[]; index: Index }) => R
+  ): Promise<R> {
+    return this.queue.push({
+      type: "modify",
+      execute: operation,
+    }) as Promise<R>;
   }
 
   async insert(document: T): Promise<T> {
@@ -114,7 +203,7 @@ class JsonCollection<T extends Document> implements Collection<T> {
       throw new Error("Document must be an object");
     }
 
-    return this.executeWriteOperation(({ data, index }) => {
+    return this.executeModifyOperation(({ data, index }) => {
       data.push(document);
       index[document.id] = data.length - 1;
 
@@ -123,13 +212,13 @@ class JsonCollection<T extends Document> implements Collection<T> {
   }
 
   async findById(id: string): Promise<T | null> {
-    return this.executeReadOperation(({ data, index }) => {
+    return this.executeQueryOperation(({ data, index }) => {
       return data[index[id]] ?? null;
     });
   }
 
   async updateById(id: string, fun: (doc: T) => T): Promise<T | null> {
-    return this.executeWriteOperation(({ data, index }) => {
+    return this.executeModifyOperation(({ data, index }) => {
       if (index[id] === undefined) {
         return null;
       }
@@ -143,7 +232,7 @@ class JsonCollection<T extends Document> implements Collection<T> {
 
   // returns true it inserted a new record
   async upsertById(id: string, fun: (doc: T | null) => T): Promise<boolean> {
-    return this.executeWriteOperation(({ data, index }) => {
+    return this.executeModifyOperation(({ data, index }) => {
       const isNewDocument = index[id] === undefined;
 
       if (isNewDocument) {
@@ -160,14 +249,17 @@ class JsonCollection<T extends Document> implements Collection<T> {
   }
 
   async all(): Promise<T[]> {
-    return this.executeReadOperation(({ data }) => {
+    return this.executeQueryOperation(({ data }) => {
       return data;
     });
   }
 }
 
+const DEFAULT_MAX_CONCURRENT_WRITES = 10;
+
 export interface Options {
   dir: string;
+  maxConcurrentWrites?: number;
   writeDelay?: number;
   encodeJson?: (data: unknown) => string;
   decodeJson?: (data: string) => unknown;
@@ -175,12 +267,31 @@ export interface Options {
 
 export function createJsonDatabase(options: Options): Database {
   const collections: Record<string, Collection<Document>> = {};
+  const writeQueue = fastq.promise(async (task: () => Promise<void>) => {
+    await task();
+  }, options.maxConcurrentWrites ?? DEFAULT_MAX_CONCURRENT_WRITES);
 
   return {
+    flushWrites: async () => {
+      // await for any delayed writes to be queued
+      await new Promise((resolve) =>
+        setTimeout(resolve, options.writeDelay ?? 0)
+      );
+
+      // await for the queue to be drained
+      await writeQueue.drained();
+
+      return;
+    },
     collection<T extends Document>(name: string): Collection<T> {
       if (collections[name] === undefined) {
         const filename = path.join(options.dir, `${name}.json`);
-        collections[name] = new JsonCollection(filename, options);
+        collections[name] = new JsonCollection(filename, {
+          queueWrite: (args) => writeQueue.push(args),
+          writeDelay: options.writeDelay,
+          encodeJson: options.encodeJson,
+          decodeJson: options.decodeJson,
+        });
       }
 
       return collections[name] as Collection<T>;

--- a/src/database/json.ts
+++ b/src/database/json.ts
@@ -68,7 +68,7 @@ class JsonCollection<T extends Document> implements Collection<T> {
   }
 
   private async load(): Promise<{ data: T[]; index: Index }> {
-    this.debouncedSave.cancel();
+    this.debouncedSave.cancel({ upcomingOnly: true });
     // Wait for any ongoing save operation to complete
     if (this.savingPromise !== null) {
       await this.savingPromise;

--- a/src/http/api/v1/exports.ts
+++ b/src/http/api/v1/exports.ts
@@ -2,11 +2,10 @@ import {
   createObjectCsvStringifier,
   createArrayCsvStringifier,
 } from "csv-writer";
-import { Database } from "chainsauce";
 import express from "express";
 import { pino } from "pino";
 
-import database from "../../../database.js";
+import { Database, createChainJsonDatabase } from "../../../database.js";
 import { createPriceProvider } from "../../../prices/provider.js";
 import { Round, Application, Vote } from "../../../indexer/types.js";
 import { getVotesWithCoefficients } from "../../../calculator/votes.js";
@@ -243,7 +242,7 @@ export const createHandler = (config: HttpApiConfig): express.Router => {
     async (req, res) => {
       const chainId = Number(req.params.chainId);
       const roundId = req.params.roundId;
-      const db = database(config.chainDataDir, chainId);
+      const db = createChainJsonDatabase(config.chainDataDir, chainId);
       const round = await db.collection<Round>("rounds").findById(roundId);
 
       if (!round) {
@@ -270,7 +269,7 @@ export const createHandler = (config: HttpApiConfig): express.Router => {
       const exportName = req.params.exportName;
       let body = "";
 
-      const db = database(config.chainDataDir, chainId);
+      const db = createChainJsonDatabase(config.chainDataDir, chainId);
       const round = await db.collection<Round>("rounds").findById(roundId);
 
       if (!round) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import {
   createIndexer,
-  createJsonDatabase,
   createSqliteCache,
   createSqliteSubscriptionStore,
   createHttpRpcClient,
@@ -24,6 +23,7 @@ import { createPriceProvider } from "./prices/provider.js";
 import { createHttpApi } from "./http/app.js";
 import { FileSystemDataProvider } from "./calculator/index.js";
 import { ethers } from "ethers";
+import { createJsonDatabase } from "./database/json.js";
 
 import abis from "./indexer/abis/index.js";
 import type { EventHandlerContext } from "./indexer/indexer.js";

--- a/src/indexer/indexer.ts
+++ b/src/indexer/indexer.ts
@@ -1,6 +1,7 @@
 import { Logger } from "pino";
 import { PriceProvider } from "../prices/provider.js";
-import { Database, Indexer as ChainsauceIndexer } from "chainsauce";
+import { Indexer as ChainsauceIndexer } from "chainsauce";
+import { Database } from "../database.js";
 
 import abis from "./abis/index.js";
 


### PR DESCRIPTION
This PR unblocks deployments.

1. Vendor in the JSON database implementation from Chainsauce, as it is not a part of the public interface anymore, it should also make things easier for us
2. Fix a big regression in performance introduced in https://github.com/gitcoinco/grants-stack-indexer/pull/315 that only surfaced in Fly with the non-blocking I/O version of the JSON database
  - The delayed writes are unbounded and they seem to be saturating the I/O in Fly, introducing a queue with a maximum concurrency of 5 works much better for Fly and doesn't affect the indexing time in my machine
  - Revert the mkdir call to happen with the delayed write instead of when reading the file, it is an expensive call for the contributions dataset, which is 6 directories deep and most contributions are new, so we're mostly creating directories and new files
3. Introduced a convenient `flushWrites` function to the database that can be awaited

Snapshots are good against `release`

----

Notes:

I created an instance in indexer-staging with an unencrypted volume to see if performance was better, it didn't seem to affect the index time and this is what I get with a simple write speed test:

```bash
# unecrypted volume
root@32874e1ef114e8:/usr/src/app# dd if=/dev/zero of=/mnt/indexer/test bs=1G count=1 oflag=dsync
1+0 records in
1+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 3.53414 s, 304 MB/s

# encrypted volume
root@3287eeeb342085:/usr/src/app#  dd if=/dev/zero of=/mnt/indexer/test bs=1G count=1 oflag=dsync
1+0 records in
1+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 2.29078 s, 469 MB/s
```

Speeds vary between 300 MB/s to 700 MB/s for both instances, I got 140 MB/s in a Google Cloud instance I had at hand, so the write speed seems reasonable.

I think it will be much clearer once we try a proper database, I know the JSON storage is not the most efficient but it's surprising to me that indexing in my laptop can take minutes and take up to 40 minutes in Fly, but it makes me wonder if this is as far as we'll get in Fly and whether this is another reason to look for another provider, I know we've already had a lot of frustrations with it but for me the biggest one is that all the work to speed up indexing seems to not carry over when running in Fly, we're on the performance CPU class and there are no other disk options.

I had a quick look at Railway but their [persistent storage offering is very lacking](https://docs.railway.app/reference/volumes#caveats), same thing [with Render](https://render.com/docs/disks#application-considerations), these two are the main competitors to Fly.

I will open a meta issue so we can discuss the situation with Fly, the switch to a database + resumable indexing will reduce these issues but it's worth having a conversation, another way to alleviate these issues would be to just use a server database like Postgres, but that comes with it's own set of trade offs, and I am not sure I like the idea of having the platform dictate our design choices, a disk based database should be perfectly reasonable.


----

```
flyctl -c fly.staging.toml deploy --wait-timeout=3600  43.56s user 22.16s system 1% cpu 1:08:52.47 total
```


---

**Conclusion**

I tested indexing in a DO droplet with their most performant offering with a dedicated CPU and got similar results as Fly, my conclusion is that the best thing to do is to continue with the work on the database and leave the JSON storage as is for now as we're just getting diminishing returns with these optimizations, but this PR is necessary to unblock while that's being done: https://github.com/gitcoinco/grants-stack-indexer/pull/338