### PR TITLE
feat: improve lookup of price by token

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import { ToBlock } from "chainsauce";
 import { z } from "zod";
 import path from "node:path";
 import abis from "./indexer/abis/index.js";
-import { Hex, Address, ChainId } from "./indexer/types.js";
+import { Address, ChainId } from "./indexer/types.js";
 
 type CoingeckoSupportedChainId = 1 | 10 | 250 | 42161 | 43114;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,9 +4,8 @@ import { ToBlock } from "chainsauce";
 import { z } from "zod";
 import path from "node:path";
 import abis from "./indexer/abis/index.js";
-import { Hex } from "./indexer/types.js";
+import { Hex, ChainId } from "./indexer/types.js";
 
-type ChainId = number;
 type CoingeckoSupportedChainId = 1 | 10 | 250 | 42161 | 43114;
 
 export type Token = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,20 +4,20 @@ import { ToBlock } from "chainsauce";
 import { z } from "zod";
 import path from "node:path";
 import abis from "./indexer/abis/index.js";
-import { Hex, ChainId } from "./indexer/types.js";
+import { Hex, Address, ChainId } from "./indexer/types.js";
 
 type CoingeckoSupportedChainId = 1 | 10 | 250 | 42161 | 43114;
 
 export type Token = {
   code: string;
-  address: string;
+  address: Address;
   decimals: number;
   priceSource: { chainId: CoingeckoSupportedChainId; address: string };
   voteAmountCap?: bigint;
 };
 
 export type Subscription = {
-  address: Hex;
+  address: Address;
   contractName: keyof typeof abis;
   fromBlock?: number;
   eventsRenames?: Record<string, string>;

--- a/src/indexer/types.ts
+++ b/src/indexer/types.ts
@@ -1,4 +1,7 @@
+export type ChainId = number;
+
 export type Hex = `0x${string}`;
+export type Address = Hex;
 
 export type MetaPtr = {
   pointer: string;

--- a/src/prices/common.ts
+++ b/src/prices/common.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { Address } from "../indexer/types.js";
 
 export type Price = {
-  token: string;
+  token: Address;
   code: string;
   price: number;
   timestamp: number;

--- a/src/prices/updater.ts
+++ b/src/prices/updater.ts
@@ -17,6 +17,7 @@ import {
 } from "./common.js";
 import { BlockCache } from "../blockCache.js";
 import { createSqliteBlockCache } from "../blockCache/sqlite.js";
+import { Address } from "../indexer/types.js";
 
 const POLL_INTERVAL_MS = 60 * 1000;
 
@@ -222,7 +223,7 @@ export function createPriceUpdater(
               }
 
               newPrices.push({
-                token: token.address.toLowerCase(),
+                token: token.address.toLowerCase() as Address,
                 code: token.code,
                 price,
                 timestamp: timestampMs,

--- a/src/test/http/app.test.ts
+++ b/src/test/http/app.test.ts
@@ -22,17 +22,26 @@ vi.spyOn(os, "hostname").mockReturnValue("dummy-hostname");
 // Typed version of supertest's Response
 type Response<T> = Omit<SupertestResponse, "body"> & { body: T };
 
-const MOCK_CHAINS = [
+const MOCK_CHAINS: Chain[] = [
   {
+    rpc: "http://localhost:8545",
+    name: "testnet",
+    pricesFromTimestamp: 0,
+    subscriptions: [],
     id: 1,
     tokens: [
       {
         code: "ETH",
+        decimals: 18,
+        priceSource: {
+          chainId: 1,
+          address: "0x0000000000000000000000000000000000000000",
+        },
         address: "0x0000000000000000000000000000000000000000",
       },
     ],
   },
-] as Chain[];
+];
 
 const DUMMY_LOGGER = {
   debug: () => {},

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { DataProvider, FileNotFoundError } from "../calculator/index.js";
 import { PassportScore } from "../passport/index.js";
 import { Price } from "../prices/common.js";
+import { Address } from "../indexer/types.js";
 
 type Fixtures = { [path: string]: string | undefined | unknown[] };
 
@@ -64,7 +65,7 @@ export class TestPriceProvider {
 
   async getUSDConversionRate(
     chainId: number,
-    tokenAddress: string,
+    tokenAddress: Address,
     _blockNumber?: number
   ): Promise<Price & { decimals: number }> {
     return Promise.resolve({


### PR DESCRIPTION
While investigating the performance regression described here: https://github.com/gitcoinco/grants-stack-indexer/pull/336, I found that a lot of the time handling the `Voted` event is spent filtering the prices by token, we now have `24_224` prices (and every time we add a new token this increases) so the impact is considerable since we iterate over them twice (once to convert to USD and then to convert to the round matching token) for each vote, and we have hundreds of thousands of votes.

This improves the lookup performance by keeping the prices indexed by tokenAddress so that no filtering is needed.

Ideally this won't be needed when we switch to a database but it's not happening before GG19 and it was a low hanging fruit.

I also started using an Address type alias in more places, there are some casts when converting to lower case but it should pave the way to this https://github.com/gitcoinco/grants-stack-indexer/issues/324