### PR TITLE
feat: log http request errors to Sentry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,7 @@ async function main(): Promise<void> {
       logger: baseLogger.child({ subsystem: "HttpApi" }),
       buildTag: config.buildTag,
       chains: config.chains,
+      enableSentry: config.sentryDsn !== null,
     });
 
     await httpApi.start();

--- a/src/test/http/app.test.ts
+++ b/src/test/http/app.test.ts
@@ -59,6 +59,7 @@ describe("server", () => {
           "passport_scores.json": "passport_scores",
         }) as DataProvider,
         chains: MOCK_CHAINS,
+        enableSentry: false,
       }).app;
     });
 
@@ -103,6 +104,7 @@ describe("server", () => {
           }) as DataProvider,
           buildTag: "123abc",
           chains: MOCK_CHAINS,
+          enableSentry: false,
         });
 
         const resp = await request(app).get(
@@ -125,6 +127,7 @@ describe("server", () => {
           }) as DataProvider,
           buildTag: "123abc",
           chains: MOCK_CHAINS,
+          enableSentry: false,
         });
 
         const resp = await request(app).get(
@@ -147,6 +150,7 @@ describe("server", () => {
           }) as DataProvider,
           buildTag: "123abc",
           chains: MOCK_CHAINS,
+          enableSentry: false,
         });
 
         const resp = await request(app).get(
@@ -169,6 +173,7 @@ describe("server", () => {
           }) as DataProvider,
           buildTag: "123abc",
           chains: MOCK_CHAINS,
+          enableSentry: false,
         });
 
         const resp = await request(app).get(
@@ -191,6 +196,7 @@ describe("server", () => {
           }) as DataProvider,
           buildTag: "123abc",
           chains: MOCK_CHAINS,
+          enableSentry: false,
         });
 
         const resp = await request(app).get(
@@ -216,6 +222,7 @@ describe("server", () => {
           }) as DataProvider,
           buildTag: "123abc",
           chains: MOCK_CHAINS,
+          enableSentry: false,
         }).app;
       });
 
@@ -396,6 +403,7 @@ describe("server", () => {
           }) as DataProvider,
           buildTag: "123abc",
           chains: MOCK_CHAINS,
+          enableSentry: false,
         }).app;
       });
 
@@ -467,6 +475,7 @@ describe("server", () => {
           }) as DataProvider,
           buildTag: "123abc",
           chains: MOCK_CHAINS,
+          enableSentry: false,
         }).app;
       });
 
@@ -537,6 +546,7 @@ describe("server", () => {
           }) as DataProvider,
           buildTag: "123abc",
           chains: MOCK_CHAINS,
+          enableSentry: false,
         }).app;
       });
 
@@ -666,6 +676,7 @@ describe("server", () => {
           }) as DataProvider,
           buildTag: "123abc",
           chains: MOCK_CHAINS,
+          enableSentry: false,
         }).app;
       });
 
@@ -890,6 +901,7 @@ describe("server", () => {
           }) as DataProvider,
           buildTag: "123abc",
           chains: MOCK_CHAINS,
+          enableSentry: false,
         }).app;
       });
 
@@ -1062,6 +1074,7 @@ describe("server", () => {
           }) as DataProvider,
           buildTag: "123abc",
           chains: MOCK_CHAINS,
+          enableSentry: false,
         }).app;
       });
 


### PR DESCRIPTION
Uses the [Sentry express middleware](https://docs.sentry.io/platforms/node/guides/express/) to increase information in case of API errors. Includes `body` in the logged information.