### PR TITLE
fix: token decimals in matching estimates

### DIFF
--- a/src/calculator/index.ts
+++ b/src/calculator/index.ts
@@ -317,15 +317,6 @@ export default class Calculator {
       }
     }
 
-    const chain = getChainConfigById(this.chainId);
-    const token = chain.tokens.find(
-      (t) => t.address.toLowerCase() === round.token.toLowerCase()
-    );
-
-    if (token === undefined) {
-      throw new UnknownTokenError(round.token, this.chainId);
-    }
-
     const conversionRateRoundToken =
       await this.priceProvider.getUSDConversionRate(this.chainId, round.token);
 

--- a/src/calculator/index.ts
+++ b/src/calculator/index.ts
@@ -334,14 +334,14 @@ export default class Calculator {
 
       const voteAmountInUsd = convertTokenToFiat({
         tokenAmount: vote.amount,
-        tokenDecimals: token.decimals,
+        tokenDecimals: tokenPrice.decimals,
         tokenPrice: tokenPrice.price,
         tokenPriceDecimals: 8,
       });
 
       const voteAmountInRoundToken = convertFiatToToken({
         fiatAmount: voteAmountInUsd,
-        tokenDecimals: tokenPrice.decimals,
+        tokenDecimals: conversionRateRoundToken.decimals,
         tokenPrice: conversionRateRoundToken.price,
         tokenPriceDecimals: 8,
       });

--- a/src/calculator/index.ts
+++ b/src/calculator/index.ts
@@ -4,7 +4,7 @@ import { linearQF, Contribution, Calculation } from "pluralistic";
 import type { PassportProvider } from "../passport/index.js";
 import { PriceProvider } from "../prices/provider.js";
 import { convertTokenToFiat, convertFiatToToken } from "../tokenMath.js";
-import { Chain, getChainConfigById, getDecimalsForToken } from "../config.js";
+import { Chain, getDecimalsForToken } from "../config.js";
 import type { Round, Application, Vote } from "../indexer/types.js";
 import { getVotesWithCoefficients, VoteWithCoefficient } from "./votes.js";
 import {
@@ -15,7 +15,7 @@ import {
   OverridesInvalidRowError,
 } from "./errors.js";
 import { PotentialVote } from "../http/api/v1/matches.js";
-import { PriceWithDecimals, UnknownTokenError } from "../prices/common.js";
+import { PriceWithDecimals } from "../prices/common.js";
 import { zeroAddress } from "viem";
 import { ProportionalMatchOptions } from "./options.js";
 


### PR DESCRIPTION
fixes issue with matching estimates in rounds where a non-18-decimal token is used

fixes #355 