### PR TITLE
Implement production tweaks done directly in Fly

### DIFF
--- a/fly.production.toml
+++ b/fly.production.toml
@@ -38,7 +38,7 @@ kill_timeout = 5
 
   [services.concurrency]
     type = "connections"
-    hard_limit = 25
+    hard_limit = 40
     soft_limit = 20
 
   [[services.tcp_checks]]

--- a/fly.production.toml
+++ b/fly.production.toml
@@ -12,7 +12,7 @@ kill_timeout = 5
   LOG_LEVEL = "debug"
   STORAGE_DIR = "/mnt/indexer"
   INDEXED_CHAINS = "mainnet,optimism,fantom,pgn-mainnet,arbitrum,arbitrum-goerli,polygon-mumbai,polygon"
-  NODE_OPTIONS="--max-old-space-size=8192"
+  NODE_OPTIONS="--max-old-space-size=7168"
   # BUILD_TAG = # set in deploy github action
 
 [processes]
@@ -38,7 +38,7 @@ kill_timeout = 5
 
   [services.concurrency]
     type = "connections"
-    hard_limit = 40
+    hard_limit = 60
     soft_limit = 20
 
   [[services.tcp_checks]]

--- a/fly.production.toml
+++ b/fly.production.toml
@@ -12,6 +12,7 @@ kill_timeout = 5
   LOG_LEVEL = "debug"
   STORAGE_DIR = "/mnt/indexer"
   INDEXED_CHAINS = "mainnet,optimism,fantom,pgn-mainnet,arbitrum,arbitrum-goerli,polygon-mumbai,polygon"
+  NODE_OPTIONS="--max-old-space-size=8192"
   # BUILD_TAG = # set in deploy github action
 
 [processes]


### PR DESCRIPTION
I had made these tweaks directly in Fly, this checks them into the config.

In production the hard limit is at 40, I want to test increasing to 60. Max old size is set to 8GB, this sets it at 7GB.

These changes were deployed evening 19th, occurrences of reaching hard connection limit errors and out of memory errors reduced significantly:

<img width="1330" alt="Screenshot 2023-11-21 at 13 53 17" src="https://github.com/gitcoinco/grants-stack-indexer/assets/711886/fde9e432-bef8-4e09-aafe-ecef49df4360">
<img width="1339" alt="Screenshot 2023-11-21 at 13 53 49" src="https://github.com/gitcoinco/grants-stack-indexer/assets/711886/bb01741b-2f1c-45f1-a21e-485878b676d9">
