### PR TITLE
Add roles relationship in graphql

### DIFF
--- a/src/database/migrate.ts
+++ b/src/database/migrate.ts
@@ -199,5 +199,10 @@ export async function migrate<T>(db: Kysely<T>, schemaName: string) {
   E'@foreignKey ("round_id", "chain_id") references ${ref(
     "rounds"
   )}(id, chain_id)|@fieldName round|@foreignFieldName donations';
+
+  comment on table ${ref("project_roles")} is
+  E'@foreignKey ("project_id") references ${ref(
+    "projects"
+  )}(id)|@fieldName project|@foreignFieldName roles';
   `.execute(db);
 }


### PR DESCRIPTION
this allows you to query project roles:

```graphql
query MyQuery {
  projects(filter: {tags: {contains: "allo-v2"}}) {
    roles {
      role
      address
    }
    chainId
    id
    tags
    registryAddress
    projectNumber
  }
}
```

to get project owners and members

```
{
  "data": {
    "projects": [
      {
        "roles": [
          {
            "role": "OWNER",
            "address": "0xe849b2a694184b8739a04c915518330757cdb18b"
          }
        ],
        "chainId": 5,
        "id": "0x00490de473481e6883b7a13f582ee8e927dce1bafa924c28407edd425aac916e",
        "tags": [
          "allo-v2"
        ],
        "registryAddress": "0x4aacca72145e1df2aec137e1f3c5e3d75db8b5f3",
        "projectNumber": 0
      },
     ....
```