### PR TITLE
improve coingecko error handling

### DIFF
--- a/src/prices/coinGecko.ts
+++ b/src/prices/coinGecko.ts
@@ -86,8 +86,7 @@ export async function fetchPricesForRange({
     },
     {
       retries: 4,
-      minTimeout: 2000,
-      maxTimeout: 10000,
+      minTimeout: 4000,
     }
   );
 

--- a/src/prices/coinGecko.ts
+++ b/src/prices/coinGecko.ts
@@ -76,7 +76,7 @@ export async function fetchPricesForRange({
         | { error: string }
         | { status: { error_code: number; error_message: string } };
 
-      if (res.status !== 429) {
+      if (res.status === 429) {
         throw new Error(
           `CoinGecko API rate limit exceeded, are you using an API key?`
         );


### PR DESCRIPTION
- coingecko returns errors in a different format that we were not handling
- we're also not explicitly retrying rate limit errors, this should improve support for running indexer without coingecko PRO