### PR TITLE
fix live indexing of votes

### DIFF
--- a/src/prices/provider.ts
+++ b/src/prices/provider.ts
@@ -181,8 +181,8 @@ export function createPriceProvider(
     const prices = await fetchPricesForRange({
       chainId: token.priceSource.chainId,
       tokenAddress: parseAddress(token.priceSource.address),
-      startTimestampInMs: blockTimestampInMs,
-      endTimestampInMs: blockTimestampInMs + twoHoursInMs,
+      startTimestampInMs: blockTimestampInMs - twoHoursInMs,
+      endTimestampInMs: blockTimestampInMs,
       coingeckoApiUrl: config.coingeckoApiUrl,
       coingeckoApiKey: config.coingeckoApiKey,
       fetch: (url, opts) => config.fetch(url, opts),


### PR DESCRIPTION
coingekco doesn't return prices if you request a time in the future, so we get the two hours previous to the block instead