### PR TITLE
add option to start http server immediately

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "start": "node dist/src/index.js",
     "start:run-once": "node dist/src/index.js --run-once | pino-pretty",
-    "dev": "tsx watch src/index.ts | pino-pretty",
-    "dev:drop-db": "tsx watch src/index.ts --drop-db | pino-pretty",
+    "dev": "tsx watch src/index.ts --http-wait-for-sync=false | pino-pretty",
+    "dev:drop-db": "tsx watch src/index.ts --http-wait-for-sync=false --drop-db | pino-pretty",
     "build": "tsc",
     "lint": "eslint src",
     "test": "vitest run --reporter verbose",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1163,6 +1163,9 @@ export function getConfig(): Config {
       "no-cache": {
         type: "boolean",
       },
+      "http-wait-for-sync": {
+        type: "boolean",
+      },
     },
   });
 
@@ -1228,7 +1231,7 @@ export function getConfig(): Config {
     .enum(["true", "false"])
     .default("true")
     .transform((value) => value === "true")
-    .parse(process.env.HTTP_SERVER_WAIT_FOR_SYNC);
+    .parse(args["http-wait-for-sync"] ?? process.env.HTTP_SERVER_WAIT_FOR_SYNC);
 
   return {
     buildTag: buildTag,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1078,6 +1078,7 @@ export type Config = {
   toBlock: ToBlock;
   passportScorerId: number;
   logLevel: "trace" | "debug" | "info" | "warn" | "error";
+  httpServerWaitForSync: boolean;
   ipfsGateway: string;
   coingeckoApiKey: string | null;
   coingeckoApiUrl: string;
@@ -1223,6 +1224,12 @@ export function getConfig(): Config {
     .default(null)
     .parse(process.env.ESTIMATES_LINEARQF_WORKER_POOL_SIZE);
 
+  const httpServerWaitForSync = z
+    .enum(["true", "false"])
+    .default("true")
+    .transform((value) => value === "true")
+    .parse(process.env.HTTP_SERVER_WAIT_FOR_SYNC);
+
   return {
     buildTag: buildTag,
     sentryDsn,
@@ -1243,6 +1250,7 @@ export function getConfig(): Config {
     databaseUrl,
     dropDb,
     databaseSchemaName,
+    httpServerWaitForSync,
     hostname: os.hostname(),
     estimatesLinearQfWorkerPoolSize,
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -201,6 +201,18 @@ async function main(): Promise<void> {
   } else {
     // Promises will be resolved once the initial catchup is done. Afterwards, services
     // will still be in listen-and-update mode.
+    //
+    const chains = config.chains.map((chain) =>
+      catchupAndWatchChain({
+        chainsauceCache,
+        chain,
+        db,
+        subscriptionStore,
+        baseLogger,
+        priceProvider,
+        ...config,
+      })
+    );
 
     const [passportProvider] = await Promise.all([
       catchupAndWatchPassport({
@@ -208,17 +220,7 @@ async function main(): Promise<void> {
         baseLogger,
         runOnce: config.runOnce,
       }),
-      ...config.chains.map((chain) =>
-        catchupAndWatchChain({
-          chainsauceCache,
-          chain,
-          db,
-          subscriptionStore,
-          baseLogger,
-          priceProvider,
-          ...config,
-        })
-      ),
+      ...(config.httpServerWaitForSync ? chains : []),
     ]);
 
     // TODO: use read only connection, use separate pool?


### PR DESCRIPTION
set `HTTP_SERVER_WAIT_FOR_SYNC=false` to have the http server start immediately and not wait for sync, also added as a cli parameter and enabled in dev by default