### PR TITLE
update strategy version

### DIFF
--- a/src/indexer/allo/v2/strategy.ts
+++ b/src/indexer/allo/v2/strategy.ts
@@ -65,6 +65,8 @@ export function extractStrategyFromId(_id: string): Strategy | null {
 
     // DonationVotingMerkleDistributionDirectTransferStrategyv1.0
     case "0x6f9291df02b2664139cec5703c124e4ebce32879c74b6297faa1468aa5ff9ebf":
+    // DonationVotingMerkleDistributionDirectTransferStrategyv1.1
+    case "0x2f46bf157821dc41daa51479e94783bb0c8699eac63bf75ec450508ab03867ce":
       return {
         id: id,
         name: "allov2.DonationVotingMerkleDistributionDirectTransferStrategy",
@@ -75,6 +77,8 @@ export function extractStrategyFromId(_id: string): Strategy | null {
 
     // DonationVotingMerkleDistributionVaultStrategyv1.0
     case "0x7e75375f0a7cd9f7ea159c8b065976e4f764f9dcef1edf692f31dd1842f70c87":
+    // DonationVotingMerkleDistributionVaultStrategyv1.1
+    case "0x093072375737c0e8872fef36808849aeba7f865e182d495f2b98308115c9ef13":
       return {
         id: id,
         name: "allov2.DonationVotingMerkleDistributionVaultStrategy",

--- a/src/indexer/allo/v2/strategy.ts
+++ b/src/indexer/allo/v2/strategy.ts
@@ -6,6 +6,7 @@ type Strategy = {
 
 export function extractStrategyFromId(_id: string): Strategy | null {
   const id = _id.toLowerCase();
+  /* eslint-disable no-fallthrough */
   switch (id) {
     // SQFSuperfluidv1
     case "0xf8a14294e80ff012e54157ec9d1b2827421f1e7f6bde38c06730b1c031b3f935":


### PR DESCRIPTION
Because of the redeployment of the DonationVotingMerkleDistribution*Strategies the strategy identifier have updated
Related issue: https://github.com/gitcoinco/grants-stack/issues/2910


Note:
the id is always a hash of `strategy name` and `strategy version` therefore a version bump results in a new id
