### PR TITLE
feat: add canonical handling

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1299,7 +1299,7 @@ export type Config = {
   estimatesLinearQfWorkerPoolSize: number | null;
 };
 
-const CHAIN_DATA_VERSION = "28";
+const CHAIN_DATA_VERSION = "29";
 
 export function getConfig(): Config {
   const buildTag = z

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -250,6 +250,7 @@ export class Database {
           .updateTable("projects")
           .set(change.project)
           .where("id", "=", change.projectId)
+          .where("chainId", "=", change.chainId)
           .execute();
         break;
       }

--- a/src/database/migrate.ts
+++ b/src/database/migrate.ts
@@ -13,6 +13,11 @@ export async function migrate<T>(db: Kysely<T>, schemaName: string) {
   const schema = db.withSchema(schemaName).schema;
 
   await schema
+    .createType("project_type")
+    .asEnum(["canonical", "linked"])
+    .execute();
+
+  await schema
     .createTable("projects")
     .addColumn("id", "text")
     .addColumn("name", "text")
@@ -27,6 +32,7 @@ export async function migrate<T>(db: Kysely<T>, schemaName: string) {
     .addColumn("createdAtBlock", BIGINT_TYPE)
     .addColumn("updatedAtBlock", BIGINT_TYPE)
     .addColumn("tags", sql`text[]`)
+    .addColumn("projectType", ref("project_type"))
 
     .addPrimaryKeyConstraint("projects_pkey", ["id", "chainId"])
     .execute();

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -73,6 +73,8 @@ export type RoundRole = Selectable<RoundRoleTable>;
 export type NewRoundRole = Insertable<RoundRoleTable>;
 export type PartialRoundRole = Updateable<RoundRoleTable>;
 
+export type ProjectType = "canonical" | "linked";
+
 export type ProjectTable = {
   id: string;
   name: string;
@@ -87,6 +89,7 @@ export type ProjectTable = {
   createdAtBlock: bigint;
   updatedAtBlock: bigint;
   tags: string[];
+  projectType: ProjectType;
 };
 
 export type Project = Selectable<ProjectTable>;

--- a/src/indexer/allo/v1/handleEvent.test.ts
+++ b/src/indexer/allo/v1/handleEvent.test.ts
@@ -187,6 +187,7 @@ describe("handleEvent", () => {
         createdByAddress: parseAddress(addressTwo),
         createdAtBlock: 1n,
         updatedAtBlock: 1n,
+        projectType: "canonical",
       };
 
       MOCK_DB.getProjectById = vi.fn().mockResolvedValueOnce(project);
@@ -236,6 +237,7 @@ describe("handleEvent", () => {
         createdByAddress: parseAddress(addressTwo),
         createdAtBlock: 1n,
         updatedAtBlock: 1n,
+        projectType: "canonical",
       };
 
       MOCK_DB.getProjectById = vi.fn().mockResolvedValueOnce(project);
@@ -379,6 +381,7 @@ describe("handleEvent", () => {
         createdByAddress: parseAddress(addressTwo),
         createdAtBlock: 1n,
         updatedAtBlock: 1n,
+        projectType: "canonical",
       };
       MOCK_DB.getProjectById = vi.fn().mockResolvedValueOnce(project);
 
@@ -428,6 +431,7 @@ describe("handleEvent", () => {
         createdByAddress: parseAddress(addressTwo),
         createdAtBlock: 1n,
         updatedAtBlock: 1n,
+        projectType: "canonical",
       };
       MOCK_DB.getProjectById = vi.fn().mockResolvedValueOnce(project);
 
@@ -474,6 +478,7 @@ describe("handleEvent", () => {
         createdByAddress: parseAddress(addressTwo),
         createdAtBlock: 1n,
         updatedAtBlock: 1n,
+        projectType: "canonical",
       };
       MOCK_DB.getProjectById = vi.fn().mockResolvedValueOnce(project);
 

--- a/src/indexer/allo/v1/handleEvent.test.ts
+++ b/src/indexer/allo/v1/handleEvent.test.ts
@@ -121,6 +121,7 @@ describe("handleEvent", () => {
           projectNumber: 1,
           registryAddress: addressOne,
           tags: ["allo-v1"],
+          projectType: "canonical",
         },
       });
 
@@ -308,6 +309,7 @@ describe("handleEvent", () => {
           projectNumber: null,
           registryAddress: addressZero,
           tags: ["allo-v1", "program"],
+          projectType: "canonical",
         },
       });
     });
@@ -329,6 +331,7 @@ describe("handleEvent", () => {
         createdByAddress: parseAddress(addressTwo),
         createdAtBlock: 1n,
         updatedAtBlock: 1n,
+        projectType: "canonical",
       };
       MOCK_DB.getProjectById = vi.fn().mockResolvedValueOnce(project);
 

--- a/src/indexer/allo/v1/handleEvent.ts
+++ b/src/indexer/allo/v1/handleEvent.ts
@@ -113,6 +113,7 @@ export async function handleEvent(
             createdByAddress: parseAddress(createdBy),
             createdAtBlock: event.blockNumber,
             updatedAtBlock: event.blockNumber,
+            projectType: "canonical",
           },
         },
         {
@@ -256,6 +257,7 @@ export async function handleEvent(
             createdByAddress: parseAddress(createdBy),
             createdAtBlock: event.blockNumber,
             updatedAtBlock: event.blockNumber,
+            projectType: "canonical",
           },
         },
       ];

--- a/src/indexer/allo/v2/handleEvent.test.ts
+++ b/src/indexer/allo/v2/handleEvent.test.ts
@@ -410,6 +410,7 @@ describe("handleEvent", () => {
           createdByAddress: parseAddress(addressTwo),
           createdAtBlock: 1n,
           updatedAtBlock: 1n,
+          projectType: "canonical",
         };
         MOCK_DB.getProjectById = vi.fn().mockResolvedValueOnce(project);
 
@@ -489,6 +490,7 @@ describe("handleEvent", () => {
         createdByAddress: parseAddress(addressTwo),
         createdAtBlock: 1n,
         updatedAtBlock: 1n,
+        projectType: "canonical",
       };
       MOCK_DB.getProjectById = vi.fn().mockResolvedValueOnce(project);
 

--- a/src/indexer/allo/v2/handleEvent.test.ts
+++ b/src/indexer/allo/v2/handleEvent.test.ts
@@ -167,6 +167,7 @@ describe("handleEvent", () => {
             projectNumber: null,
             registryAddress: addressOne,
             tags: ["allo-v2"],
+            projectType: "canonical",
           },
         });
 
@@ -249,6 +250,7 @@ describe("handleEvent", () => {
             projectNumber: null,
             registryAddress: addressOne,
             tags: ["allo-v2"],
+            projectType: "canonical",
           },
         });
 

--- a/src/indexer/allo/v2/handleEvent.ts
+++ b/src/indexer/allo/v2/handleEvent.ts
@@ -29,8 +29,8 @@ function generateRoundRoles(poolId: bigint) {
 function getProjectType(metadata: object) {
   const linkedProjectMetadata = z.object({
     canonical: z.object({
-      chainId: z.number(),
       registryAddress: z.string(),
+      chainId: z.coerce.number(),
     }),
   });
 
@@ -392,6 +392,7 @@ export async function handleEvent(
     case "ProfileMetadataUpdated": {
       const metadataCid = event.params.metadata.pointer;
       const metadata = await ipfsGet<ProjectTable["metadata"]>(metadataCid);
+
       return [
         {
           type: "UpdateProject",

--- a/src/indexer/allo/v2/handleEvent.ts
+++ b/src/indexer/allo/v2/handleEvent.ts
@@ -29,7 +29,7 @@ function generateRoundRoles(poolId: bigint) {
 function getProjectType(metadata: object) {
   const linkedProjectMetadata = z.object({
     canonical: z.object({
-      chainId: z.string(),
+      chainId: z.number(),
       registryAddress: z.string(),
     }),
   });

--- a/src/indexer/types.ts
+++ b/src/indexer/types.ts
@@ -117,8 +117,3 @@ export type DVMDApplicationData = {
     pointer: string;
   };
 };
-
-export type CanonicalProject = {
-  chainId: number;
-  registryAddress: string;
-};

--- a/src/indexer/types.ts
+++ b/src/indexer/types.ts
@@ -117,3 +117,8 @@ export type DVMDApplicationData = {
     pointer: string;
   };
 };
+
+export type CanonicalProject = {
+  chainId: number;
+  registryAddress: string;
+};


### PR DESCRIPTION
#### When creating a linked Profile and the canonical already exists

```
{
  projects(
    filter: {id: {equalTo: "0xbfe075166257fda5b915e3dda8be67b44b2db34ddf476841b1e7aa33a5e13db2"}}
  ) {
    id
    chainId
    projectType
    metadata
  }
}
```

<img width="1000" alt="image" src="https://github.com/gitcoinco/grants-stack-indexer/assets/5358146/2831d267-1879-4d62-aa8b-cb8ba0f9454f">


#### When attempting to create a linked Profile BUT the canonical does not exist

<img width="1000" alt="image" src="https://github.com/gitcoinco/grants-stack-indexer/assets/5358146/7e989e59-0981-407f-bda4-6cc1eb26edaa">

Fixes https://github.com/gitcoinco/grants-stack-indexer/issues/427