### PR TITLE
add timezone info to timestamps

### DIFF
--- a/src/database/migrate.ts
+++ b/src/database/migrate.ts
@@ -88,10 +88,10 @@ export async function migrate<T>(db: Kysely<T>, schemaName: string) {
     .addColumn("roundMetadataCid", "text")
     .addColumn("roundMetadata", "jsonb")
 
-    .addColumn("applicationsStartTime", "timestamp")
-    .addColumn("applicationsEndTime", "timestamp")
-    .addColumn("donationsStartTime", "timestamp")
-    .addColumn("donationsEndTime", "timestamp")
+    .addColumn("applicationsStartTime", "timestamptz")
+    .addColumn("applicationsEndTime", "timestamptz")
+    .addColumn("donationsStartTime", "timestamptz")
+    .addColumn("donationsEndTime", "timestamptz")
 
     .addColumn("createdByAddress", ADDRESS_TYPE)
     .addColumn("createdAtBlock", BIGINT_TYPE)
@@ -258,7 +258,7 @@ export async function migrate<T>(db: Kysely<T>, schemaName: string) {
     .addColumn("chainId", CHAIN_ID_TYPE)
     .addColumn("tokenAddress", ADDRESS_TYPE)
     .addColumn("priceInUSD", "real")
-    .addColumn("timestamp", "timestamp")
+    .addColumn("timestamp", "timestamptz")
     .addColumn("blockNumber", BIGINT_TYPE)
     .execute();
 


### PR DESCRIPTION
- pg seems to always store the date in local time instead of UTC, adding timezone information allows us to not lose that information, this is an issue in local development
- saving with the timezone the graphql api returns dates as "2024-02-20T17:00:00+00:00" instead of just "2024-02-20T17:00:00" so they get correctly interpreted as UTC in the front end