### PR TITLE
fix passport updater

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ import os from "node:os";
 type ChainId = number;
 type CoingeckoSupportedChainId = 1 | 10 | 250 | 42161 | 43114;
 
-const CHAIN_DATA_VERSION = "33";
+const CHAIN_DATA_VERSION = "34";
 
 export type Token = {
   code: string;

--- a/src/passport/index.ts
+++ b/src/passport/index.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
-import fastq, { queueAsPromised } from "fastq";
 import split2 from "split2";
 import { Level } from "level";
 import enhancedFetch from "make-fetch-happen";


### PR DESCRIPTION
the passport score queue grows faster than the consumer can process

this replaces the usage of a queue with native node js streams, we process items one by one as they come and node's back pressure should do the rest