### PR TITLE
add canonical project to application

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ import os from "node:os";
 type ChainId = number;
 type CoingeckoSupportedChainId = 1 | 10 | 250 | 42161 | 43114;
 
-const CHAIN_DATA_VERSION = "36";
+const CHAIN_DATA_VERSION = "37";
 
 export type Token = {
   code: string;

--- a/src/database/migrate.ts
+++ b/src/database/migrate.ts
@@ -275,9 +275,9 @@ export async function migrate<T>(db: Kysely<T>, schemaName: string) {
   E'@foreignFieldName applications\n@fieldName round';
 
   comment on table ${ref("applications")} is
-  E'@foreignKey ("project_id") references ${ref(
+  E'@foreignKey ("project_id", "chain_id") references ${ref(
     "projects"
-  )}(id)|@fieldName project';
+  )}(id, chain_id)|@fieldName project';
 
   comment on table ${ref("donations")} is
   E'@foreignKey ("application_id", "round_id", "chain_id") references ${ref(

--- a/src/database/migrate.ts
+++ b/src/database/migrate.ts
@@ -279,6 +279,16 @@ export async function migrate<T>(db: Kysely<T>, schemaName: string) {
     "projects"
   )}(id, chain_id)|@fieldName project';
 
+  create function ${ref("applications_canonical_project")}(a ${ref(
+    "applications"
+  )} ) returns ${ref("projects")} as $$
+    select *
+    from ${ref("projects")}
+    where id = a.project_id
+    and project_type = 'canonical'
+    limit 1;
+  $$ language sql stable;
+
   comment on table ${ref("donations")} is
   E'@foreignKey ("application_id", "round_id", "chain_id") references ${ref(
     "applications"

--- a/src/database/migrate.ts
+++ b/src/database/migrate.ts
@@ -275,9 +275,9 @@ export async function migrate<T>(db: Kysely<T>, schemaName: string) {
   E'@foreignFieldName applications\n@fieldName round';
 
   comment on table ${ref("applications")} is
-  E'@foreignKey ("project_id", "chain_id") references ${ref(
+  E'@foreignKey ("project_id") references ${ref(
     "projects"
-  )}(id, chain_id)|@fieldName project';
+  )}(id)|@fieldName project';
 
   create function ${ref("applications_canonical_project")}(a ${ref(
     "applications"


### PR DESCRIPTION
- this adds a `canonicalProject` to the application, so that we can get the canonical information without having to query multiple tables

this works for now but there are some considerations:

at the moment the project relationship under applications will error if a project has a linked and a canonical project, try this query, it will fail:

```graphql
{
  applications(
    condition: {chainId: 11155111, roundId: "47"}  ) {
    id
    projectId
    statusSnapshots
    project {
      id
      projectType
    }
  }
```

- technically you can have multiple canonical projects so this canonicalProject relation will not work at some point

- i think the proper solution should be to have a many to many between projects and applications, and have a single project relation as well that takes into account the chain Id of the project