### PR TITLE
fix: disabled matching cap

### DIFF
--- a/src/calculator/calculationConfig.ts
+++ b/src/calculator/calculationConfig.ts
@@ -28,7 +28,7 @@ export function extractCalculationConfigFromRound(
 
   let matchingCapAmount: bigint | undefined = undefined;
 
-  if (round.metadata?.quadraticFundingConfig?.matchingCap !== undefined) {
+  if (round.metadata?.quadraticFundingConfig?.matchingCapAmount !== undefined) {
     // round.metadata.quadraticFundingConfig.matchingCapAmount is a percentage,
     // from 0 to 100, and can have decimals
     const capPercentage =


### PR DESCRIPTION
disabling matching cap is not working at the moment for the QF calculator, this means that rounds with disabled matching cap will have a matching cap set to 0 so projects will not get matches, I suspect all rounds that we've had have matching cap so it was never an issue