### PR TITLE
fix error reporting

### DIFF
--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -13,6 +13,7 @@ kill_timeout = 5
   STORAGE_DIR = "/mnt/indexer"
   INDEXED_CHAINS = "mainnet,optimism,fantom,pgn-testnet,pgn-mainnet,arbitrum,polygon-mumbai,polygon,sepolia,avalanche,avalanche-fuji,scroll,scroll-sepolia,base,zksync-era-mainnet"
   ENABLE_RESOURCE_MONITOR = "true"
+  NODE_OPTIONS="--max-old-space-size=7168"
   # BUILD_TAG = # set in deploy github action
 
 [processes]

--- a/src/index.ts
+++ b/src/index.ts
@@ -570,6 +570,7 @@ async function catchupAndWatchChain(
       msg: `error during initial catch up with chain ${config.chain.id}`,
       err,
     });
+    Sentry.captureException(err);
     throw err;
   }
 }

--- a/src/indexer/allo/v1/handleEvent.ts
+++ b/src/indexer/allo/v1/handleEvent.ts
@@ -164,7 +164,7 @@ export async function handleEvent(
       const project = await db.getProjectById(chainId, projectId);
 
       if (project === null) {
-        logger.error({
+        logger.warn({
           msg: `Project ${chainId}/${projectId} not found`,
           event,
         });
@@ -195,7 +195,7 @@ export async function handleEvent(
       const project = await db.getProjectById(chainId, projectId);
 
       if (project === null) {
-        logger.error({
+        logger.warn({
           msg: `Project ${chainId}/${projectId} not found`,
           event,
         });
@@ -687,7 +687,7 @@ export async function handleEvent(
               ).amount;
       } catch (err) {
         if (err instanceof UnknownTokenError) {
-          logger.error({
+          logger.warn({
             msg: `Skipping event ${event.name} on chain ${chainId} due to unknown token ${roundMatchTokenAddress}`,
             err,
             event,
@@ -794,7 +794,7 @@ export async function handleEvent(
         MatchingDistributionSchema.safeParse(rawDistribution);
 
       if (!distribution.success) {
-        logger.error({
+        logger.warn({
           msg: "Failed to parse distribution",
           error: distribution.error,
           event,

--- a/src/indexer/allo/v1/roleGranted.ts
+++ b/src/indexer/allo/v1/roleGranted.ts
@@ -29,7 +29,7 @@ export default async function handleEvent(
       const programAddress = parseAddress(event.address);
       const project = await db.getProjectById(chainId, programAddress);
       if (project === null) {
-        logger.error({
+        logger.warn({
           msg: `Program/Project ${programAddress} not found`,
           event,
         });
@@ -71,7 +71,7 @@ export default async function handleEvent(
         }
 
         default: {
-          logger.error({
+          logger.warn({
             msg: `Unknown role ${role} for program ${programAddress}`,
             event,
           });
@@ -85,7 +85,7 @@ export default async function handleEvent(
       const roundAddress = parseAddress(event.address);
       const round = await db.getRoundById(chainId, roundAddress);
       if (round === null) {
-        logger.error({
+        logger.warn({
           msg: `Round ${chainId}/${roundAddress} not found`,
           event,
         });
@@ -127,7 +127,7 @@ export default async function handleEvent(
         }
 
         default: {
-          logger.error({
+          logger.warn({
             msg: `Unknown role ${role} for round ${roundAddress}`,
             event,
           });

--- a/src/indexer/allo/v1/roleRevoked.ts
+++ b/src/indexer/allo/v1/roleRevoked.ts
@@ -27,7 +27,7 @@ export default async function handleEvent(
       const programAddress = parseAddress(event.address);
       const project = await db.getProjectById(chainId, programAddress);
       if (project === null) {
-        logger.error({
+        logger.warn({
           msg: `Program/Project ${programAddress} not found`,
           event,
         });
@@ -67,7 +67,7 @@ export default async function handleEvent(
         }
 
         default: {
-          logger.error({
+          logger.warn({
             msg: `Unknown role ${role} for program ${programAddress}`,
             event,
           });
@@ -81,7 +81,7 @@ export default async function handleEvent(
       const roundAddress = parseAddress(event.address);
       const round = await db.getRoundById(chainId, roundAddress);
       if (round === null) {
-        logger.error({
+        logger.warn({
           msg: `Round ${roundAddress} not found`,
           event,
         });
@@ -121,7 +121,7 @@ export default async function handleEvent(
         }
 
         default: {
-          logger.error({
+          logger.warn({
             msg: `Unknown role ${role} for program ${roundAddress}`,
             event,
           });

--- a/src/indexer/allo/v2/handleEvent.ts
+++ b/src/indexer/allo/v2/handleEvent.ts
@@ -878,7 +878,7 @@ export async function handleEvent(
         MatchingDistributionSchema.safeParse(rawDistribution);
 
       if (!distribution.success) {
-        logger.error({
+        logger.warn({
           msg: "Failed to parse distribution",
           error: distribution.error,
           event,

--- a/src/indexer/allo/v2/handleEvent.ts
+++ b/src/indexer/allo/v2/handleEvent.ts
@@ -1020,7 +1020,7 @@ export async function handleEvent(
                   ).amount;
           } catch (err) {
             if (err instanceof UnknownTokenError) {
-              logger.error({
+              logger.warn({
                 msg: `Skipping event ${event.name} on chain ${chainId} due to unknown token ${roundMatchTokenAddress}`,
                 err,
                 event,


### PR DESCRIPTION
fixes #437 

- demote errors that should be warnings to reduce amount of log noise
- send catch up errors to sentry