### PR TITLE
fix project application relationship

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ import os from "node:os";
 type ChainId = number;
 type CoingeckoSupportedChainId = 1 | 10 | 250 | 42161 | 43114;
 
-const CHAIN_DATA_VERSION = "54";
+const CHAIN_DATA_VERSION = "55";
 
 export type Token = {
   code: string;


### PR DESCRIPTION
at the moment the project inside application fails for allo v2 because there are multiple projects matching the project id

this modifies sot that application => project will always be the actual project that was applied with, ignoring canonical

in allo v2 this project is equal to the project id and chain id of the application
in allo v1 the project_id is already unique across chains


