### PR TITLE
improve database donation background processing

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -22,7 +22,6 @@ import { Logger } from "pino";
 import { LRUCache } from "lru-cache";
 import { Address } from "../address.js";
 import { ChainId } from "../types.js";
-import { warn } from "node:console";
 
 export type { DataChange as Changeset };
 

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -122,7 +122,6 @@ export class Database {
     }
 
     this.#statsTimeout = setTimeout(async () => {
-      this.#statsTimeout = null;
       try {
         await this.updateStats();
       } catch (error) {
@@ -189,7 +188,6 @@ export class Database {
     }
 
     this.#donationBatchTimeout = setTimeout(async () => {
-      this.#donationBatchTimeout = null;
       try {
         await this.flushDonationQueue();
       } catch (error) {

--- a/src/deprecatedJsonDatabase.ts
+++ b/src/deprecatedJsonDatabase.ts
@@ -63,6 +63,7 @@ export function createDeprecatedApplication(
   return {
     id: application.id,
     projectId: application.projectId,
+    anchorAddress: application.anchorAddress,
     status: application.status,
     amountUSD: application.totalAmountDonatedInUsd,
     votes: application.totalDonationsCount,
@@ -153,6 +154,7 @@ export type DeprecatedApplication = {
   amountUSD: number;
   votes: number;
   uniqueContributors: number;
+  anchorAddress: string | null;
   metadata: {
     application: {
       project: {

--- a/src/test/calculator/proportionalMatch.test.fixtures.ts
+++ b/src/test/calculator/proportionalMatch.test.fixtures.ts
@@ -79,6 +79,7 @@ const applications: DeprecatedApplication[] = [
   {
     id: "application-id-1",
     projectId: "project-id-1",
+    anchorAddress: "0x1234",
     roundId: "0x1234",
     status: "APPROVED",
     amountUSD: 0,

--- a/src/test/calculator/votes.test.ts
+++ b/src/test/calculator/votes.test.ts
@@ -31,6 +31,7 @@ const applications: DeprecatedApplication[] = [
   {
     id: "application-id-1",
     projectId: "project-id-1",
+    anchorAddress: "0x1234",
     roundId: "0x1234",
     status: "APPROVED",
     amountUSD: 0,


### PR DESCRIPTION
because of the large amount of votes we have, there are two processes that happen in the background instead of blocking the event loop:

- update round & application stats (once every minute)
- insert votes to the database (once every 5 seconds)

this PR improves them:

- on each loop, wait for the current task to finish before scheduling the next one, i suspect this might cause the database to overload during high load as we could end up with overlapping work
- handle insert errors so that they're retried, this could be a place where donations are lost if the database fails for some reason, the stats are not a problem since there's no data "to lose"
- add some error handling to improve debuggability