### PR TITLE
only enable postgraphile pro if env is present

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,6 @@ DATABASE_URL=postgres://postgres:postgres@localhost:5432/grants_stack_indexer
 
 #COINGECKO_API_KEY=
 #IPFS_GATEWAY=
+
+# optional, enable the Postgraphile Pro plugin: https://www.npmjs.com/package/@graphile/pro
+#GRAPHILE_LICENSE

--- a/docs/deploy-to-fly.md
+++ b/docs/deploy-to-fly.md
@@ -15,15 +15,21 @@ Next, clone the repository and make necessary adjustments to the `fly.toml` file
 
 ## Deployment
 
-After configuring, deploy your app with:
+After configuring, deploy your app with the launch command. It will detect the existing `fly.toml` in the repository and make a new app based on that. It will also launch a Postgres database and automatically add the `DATABASE_URL` secret for you.
 
-    fly launch --copy-config
+You might want to specify the `--org` parameter to launch the app in the right organization. Run `fly orgs list` to see the orgs you're part of.
+
+```sh
+fly launch --copy-config
+```
 
 Monitor the deployment process and troubleshoot if necessary by running:
 
-    fly logs
+```sh
+fly logs
+```
 
-Note that because of the amount of events Allo contracts emit, the first run might take hours.
+Note that because of the number of events Allo contracts emit, the first run might take hours. Depending on the RPCs, it might even fail. Ensure you monitor progress and update RPCs if necessary.
 
 ## Access Your Indexer
 

--- a/fly.toml
+++ b/fly.toml
@@ -9,7 +9,7 @@ kill_timeout = '5s'
 [build]
 
 [deploy]
-  wait_timeout = '3h0m0s'
+  wait_timeout = '6h0m0s'
 
 [env]
   DEPLOYMENT_ENVIRONMENT = 'production'

--- a/fly.toml
+++ b/fly.toml
@@ -9,7 +9,7 @@ kill_timeout = '5s'
 [build]
 
 [deploy]
-  wait_timeout = '1h0m0s'
+  wait_timeout = '3h0m0s'
 
 [env]
   DEPLOYMENT_ENVIRONMENT = 'production'

--- a/src/index.ts
+++ b/src/index.ts
@@ -295,7 +295,9 @@ async function main(): Promise<void> {
       ...(config.httpServerWaitForSync ? [indexChainsPromise] : []),
     ]);
 
-    const pluginHook = makePluginHook([GraphilePro.default]);
+    const pluginHook = process.env.GRAPHILE_LICENSE
+      ? makePluginHook([GraphilePro.default])
+      : undefined;
 
     const graphqlHandler = postgraphile(
       readOnlyDatabaseConnectionPool,


### PR DESCRIPTION
- update some docs and document postgraphile pro
- do not enable postgraphile pro if the env is not set, this is because postgraphile shows a warning that could be confusing
- increase the deploy timeout to 3h, fresh reindexes could take a while