### PR TITLE
DG: fetch token/match info only if token available

### DIFF
--- a/src/indexer/allo/v1/handleEvent.ts
+++ b/src/indexer/allo/v1/handleEvent.ts
@@ -900,25 +900,36 @@ export async function handleEvent(
         return [];
       }
 
-      const amountInUsd = (
-        await convertToUSD(
-          priceProvider,
-          chainId,
-          parseAddress(event.params.token),
-          amount,
-          event.blockNumber
-        )
-      ).amount;
+      let amountInUsd = 0;
+      let amountInRoundMatchToken = 0n;
 
-      const amountInRoundMatchToken = (
-        await convertFromUSD(
-          priceProvider,
-          chainId,
-          roundMatchTokenAddress,
-          amountInUsd,
-          event.blockNumber
-        )
-      ).amount;
+      try {
+        amountInUsd = (
+          await convertToUSD(
+            priceProvider,
+            chainId,
+            parseAddress(event.params.token),
+            amount,
+            event.blockNumber
+          )
+        ).amount;
+
+        amountInRoundMatchToken = (
+          await convertFromUSD(
+            priceProvider,
+            chainId,
+            roundMatchTokenAddress,
+            amountInUsd,
+            event.blockNumber
+          )
+        ).amount;
+      } catch (error) {
+        logger.warn({
+          msg: "Token not found: Failed to convert amount to USD",
+          error,
+          event,
+        });
+      }
 
       const timestamp = getDateFromTimestamp(
         BigInt((await blockTimestampInMs(chainId, event.blockNumber)) / 1000)

--- a/src/indexer/allo/v2/handleEvent.ts
+++ b/src/indexer/allo/v2/handleEvent.ts
@@ -1100,26 +1100,36 @@ export async function handleEvent(
             recipientId
           );
 
-          const amountInUsd = (
-            await convertToUSD(
-              priceProvider,
-              chainId,
-              tokenAddress,
-              amount,
-              event.blockNumber
-            )
-          ).amount;
+          let amountInUsd = 0;
+          let amountInRoundMatchToken = 0n;
 
-          const amountInRoundMatchToken = (
-            await convertFromUSD(
-              priceProvider,
-              chainId,
-              tokenAddress,
-              amountInUsd,
-              event.blockNumber
-            )
-          ).amount;
+          try {
+            amountInUsd = (
+              await convertToUSD(
+                priceProvider,
+                chainId,
+                tokenAddress,
+                amount,
+                event.blockNumber
+              )
+            ).amount;
 
+            amountInRoundMatchToken = (
+              await convertFromUSD(
+                priceProvider,
+                chainId,
+                tokenAddress,
+                amountInUsd,
+                event.blockNumber
+              )
+            ).amount;
+          } catch (error) {
+            logger.warn({
+              msg: "Token not found: Failed to convert amount to USD",
+              error,
+              event,
+            });
+          }
           const timestamp = getDateFromTimestamp(
             BigInt(
               (await blockTimestampInMs(chainId, event.blockNumber)) / 1000


### PR DESCRIPTION
To enable using custom tokes on direct grants, this PR makes the amount in usd and match token info optional. Since direct grants does not have a matching pool and a match token and we do not display the USD value on the frontend, we default them to 0.

That allows us to insert the application payout without this information, else the payout would be dropped.