### PR TITLE
fix: use new tokens for deployment workflows

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -2,14 +2,14 @@ name: Check Pull Request
 
 on:
   pull_request:
-    branches: "**"
+    branches: ["*"]
 
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up fly
         uses: superfly/flyctl-actions/setup-flyctl@master
@@ -19,6 +19,6 @@ jobs:
         run: |
           flyctl -c fly.staging.toml deploy --remote-only --build-only
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_STAGE }}
 
 

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up fly
         uses: superfly/flyctl-actions/setup-flyctl@master
@@ -30,7 +30,7 @@ jobs:
         run: |
           flyctl -c ${{ env.FLY_CONFIG }} deploy --remote-only --build-only --push --image-label deployment-$GIT_SHA_SHORT
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PRODUCTION }}
 
       - name: Deploy Indexer
         run: |


### PR DESCRIPTION
- Created independent deployment tokens with my user for indexer-v2 and indexer-v2-staging in fly
- Created new secrets in GH to store the newly created tokens (FLY_API_TOKEN_(STAGE|PRODUCTION)
- Uptated the workflows to use the new tokens
- Upgraded actions/checkout to V4