### PR TITLE
chore: removing TEC

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -209,7 +209,7 @@ const CHAINS: Chain[] = [
           chainId: 10,
           address: "0x4200000000000000000000000000000000000042",
         },
-      }
+      },
     ],
     subscriptions: [
       {

--- a/src/config.ts
+++ b/src/config.ts
@@ -209,16 +209,7 @@ const CHAINS: Chain[] = [
           chainId: 10,
           address: "0x4200000000000000000000000000000000000042",
         },
-      },
-      {
-        code: "TEC",
-        address: "0x8fc7c1109c08904160d6ae36482b79814d45eb78",
-        decimals: 18,
-        priceSource: {
-          chainId: 10,
-          address: "0x8fc7c1109c08904160d6ae36482b79814d45eb78",
-        },
-      },
+      }
     ],
     subscriptions: [
       {


### PR DESCRIPTION
The TEC token does not support the Permit functions so checkout cannot be completed, removing it so it doesn't cause issues for users.