### PR TITLE
store IPFS data in it's own table 

### DIFF
--- a/docs/reindexing.md
+++ b/docs/reindexing.md
@@ -12,9 +12,13 @@ When deploying changes to the indexer, it's important to clarify the results you
     - The indexer will create a new schema in Postgres named `chain_data_${version}`. If this schema does not exist, it will be created, all necessary tables will be set up, and indexing will start from scratch.
     - If the schema already exists, the indexer will resume indexing from the last indexed block unless the `--drop-db` flag is specified via the CLI. This will drop the existing database and start fresh.
 
-### Using `--drop-db` in Development
+### Using `--drop-db` | `--drop-chain-db` | `--drop-ipfs-db` in Development
 
-- During development, you can use the `--drop-db` flag to ensure the indexer always deletes the existing schema and migrates from scratch. This can be useful for testing schema changes and event handler modifications without retaining old data.
+- During development, you can use the `--drop-db` flag to ensure the indexer always deletes all existing schema and migrates from scratch. This can be useful for testing schema changes and event handler modifications without retaining old data.
+
+- During development, you can use the `--drop-chain-db` flag to ensure the indexer always deletes chain schema and migrates from scratch. 
+
+- During development, you can use the `--drop-ipfs-db` flag to ensure the indexer always deletes ipfs schema and migrates from scratch. 
 
 ### Important Notes
 

--- a/docs/reindexing.md
+++ b/docs/reindexing.md
@@ -12,13 +12,15 @@ When deploying changes to the indexer, it's important to clarify the results you
     - The indexer will create a new schema in Postgres named `chain_data_${version}`. If this schema does not exist, it will be created, all necessary tables will be set up, and indexing will start from scratch.
     - If the schema already exists, the indexer will resume indexing from the last indexed block unless the `--drop-db` flag is specified via the CLI. This will drop the existing database and start fresh.
 
-### Using `--drop-db` | `--drop-chain-db` | `--drop-ipfs-db` in Development
+### Dropping Schemas in Development
 
 - During development, you can use the `--drop-db` flag to ensure the indexer always deletes all existing schema and migrates from scratch. This can be useful for testing schema changes and event handler modifications without retaining old data.
 
 - During development, you can use the `--drop-chain-db` flag to ensure the indexer always deletes chain schema and migrates from scratch. 
 
 - During development, you can use the `--drop-ipfs-db` flag to ensure the indexer always deletes ipfs schema and migrates from scratch. 
+
+- During development, you can use the `--drop-price-db` flag to ensure the indexer always deletes price schema and migrates from scratch. 
 
 ### Important Notes
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,7 @@ type CoingeckoSupportedChainId =
 
 const CHAIN_DATA_VERSION = "81";
 const IPFS_DATA_VERSION = "1";
+const PRICE_DATA_VERSION = "1";
 
 export type Token = {
   code: string;
@@ -1832,6 +1833,8 @@ export type Config = {
   databaseSchemaName: string;
   ipfsDataVersion: string;
   ipfsDatabaseSchemaName: string;
+  priceDataVersion: string;
+  priceDatabaseSchemaName: string;
   hostname: string;
   pinoPretty: boolean;
   deploymentEnvironment: "local" | "development" | "staging" | "production";
@@ -1839,6 +1842,7 @@ export type Config = {
   dropDb: boolean;
   dropChainDb: boolean;
   dropIpfsDb: boolean;
+  dropPriceDb: boolean;
   removeCache: boolean;
   estimatesLinearQfWorkerPoolSize: number | null;
 };
@@ -1910,6 +1914,9 @@ export function getConfig(): Config {
         type: "boolean",
       },
       "drop-ipfs-db": {
+        type: "boolean",
+      },
+      "drop-price-db": {
         type: "boolean",
       },
       "rm-cache": {
@@ -2003,9 +2010,13 @@ export function getConfig(): Config {
   const ipfsDataVersion = IPFS_DATA_VERSION;
   const ipfsDatabaseSchemaName = `ipfs_data_${ipfsDataVersion}`;
 
+  const priceDataVersion = PRICE_DATA_VERSION;
+  const priceDatabaseSchemaName = `price_data_${priceDataVersion}`;
+
   const dropDb = z.boolean().default(false).parse(args["drop-db"]);
   const dropChainDb = z.boolean().default(false).parse(args["drop-chain-db"]);
   const dropIpfsDb = z.boolean().default(false).parse(args["drop-ipfs-db"]);
+  const dropPriceDb = z.boolean().default(false).parse(args["drop-price-db"]);
 
   const removeCache = z.boolean().default(false).parse(args["rm-cache"]);
 
@@ -2056,11 +2067,14 @@ export function getConfig(): Config {
     dropDb,
     dropChainDb,
     dropIpfsDb,
+    dropPriceDb,
     removeCache,
     dataVersion,
     databaseSchemaName,
     ipfsDataVersion,
     ipfsDatabaseSchemaName,
+    priceDataVersion,
+    priceDatabaseSchemaName,
     httpServerWaitForSync,
     httpServerEnabled,
     indexerEnabled,

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,7 @@ type CoingeckoSupportedChainId =
   | 1088;
 
 const CHAIN_DATA_VERSION = "81";
+const IPFS_DATA_VERSION = "1";
 
 export type Token = {
   code: string;
@@ -1829,11 +1830,15 @@ export type Config = {
   readOnlyDatabaseUrl: string;
   dataVersion: string;
   databaseSchemaName: string;
+  ipfsDataVersion: string;
+  ipfsDatabaseSchemaName: string;
   hostname: string;
   pinoPretty: boolean;
   deploymentEnvironment: "local" | "development" | "staging" | "production";
   enableResourceMonitor: boolean;
   dropDb: boolean;
+  dropChainDb: boolean;
+  dropIpfsDb: boolean;
   removeCache: boolean;
   estimatesLinearQfWorkerPoolSize: number | null;
 };
@@ -1899,6 +1904,12 @@ export function getConfig(): Config {
         type: "string",
       },
       "drop-db": {
+        type: "boolean",
+      },
+      "drop-chain-db": {
+        type: "boolean",
+      },
+      "drop-ipfs-db": {
         type: "boolean",
       },
       "rm-cache": {
@@ -1989,7 +2000,12 @@ export function getConfig(): Config {
   const dataVersion = CHAIN_DATA_VERSION;
   const databaseSchemaName = `chain_data_${dataVersion}`;
 
+  const ipfsDataVersion = IPFS_DATA_VERSION;
+  const ipfsDatabaseSchemaName = `ipfs_data_${ipfsDataVersion}`;
+
   const dropDb = z.boolean().default(false).parse(args["drop-db"]);
+  const dropChainDb = z.boolean().default(false).parse(args["drop-chain-db"]);
+  const dropIpfsDb = z.boolean().default(false).parse(args["drop-ipfs-db"]);
 
   const removeCache = z.boolean().default(false).parse(args["rm-cache"]);
 
@@ -2038,9 +2054,13 @@ export function getConfig(): Config {
     databaseUrl,
     readOnlyDatabaseUrl,
     dropDb,
+    dropChainDb,
+    dropIpfsDb,
     removeCache,
     dataVersion,
     databaseSchemaName,
+    ipfsDataVersion,
+    ipfsDatabaseSchemaName,
     httpServerWaitForSync,
     httpServerEnabled,
     indexerEnabled,

--- a/src/database/changeset.ts
+++ b/src/database/changeset.ts
@@ -16,6 +16,7 @@ import {
   NewPrice,
   NewLegacyProject,
   NewApplicationPayout,
+  NewIpfsData,
 } from "./schema.js";
 
 export type DataChange =
@@ -140,4 +141,8 @@ export type DataChange =
   | {
       type: "InsertApplicationPayout";
       payout: NewApplicationPayout;
+    }
+  | {
+      type: "InsertIpfsData";
+      ipfs: NewIpfsData;
     };

--- a/src/database/migrate.ts
+++ b/src/database/migrate.ts
@@ -392,3 +392,13 @@ export async function migrate<T>(db: Kysely<T>, schemaName: string) {
   $$ language sql stable;
   `.execute(db);
 }
+
+export async function migrateDataFetcher<T>(db: Kysely<T>, schemaName: string) {
+  const schema = db.withSchema(schemaName).schema;
+
+  await schema
+    .createTable("ipfs_data")
+    .addColumn("cid", "text")
+    .addColumn("data", "jsonb")
+    .execute();
+}

--- a/src/database/migrate.ts
+++ b/src/database/migrate.ts
@@ -298,22 +298,6 @@ export async function migrate<T>(db: Kysely<T>, schemaName: string) {
     .execute();
 
   await schema
-    .createTable("prices")
-    .addColumn("id", "serial", (cb) => cb.primaryKey())
-    .addColumn("chainId", CHAIN_ID_TYPE)
-    .addColumn("tokenAddress", ADDRESS_TYPE)
-    .addColumn("priceInUSD", "real")
-    .addColumn("timestamp", "timestamptz")
-    .addColumn("blockNumber", BIGINT_TYPE)
-    .execute();
-
-  await db.schema
-    .createIndex("idx_prices_chain_token_block")
-    .on("prices")
-    .expression(sql`chain_id, token_address, block_number DESC`)
-    .execute();
-
-  await schema
     .createTable("legacy_projects")
     .addColumn("id", "serial", (col) => col.primaryKey())
     .addColumn("v1ProjectId", "text")
@@ -400,5 +384,28 @@ export async function migrateDataFetcher<T>(db: Kysely<T>, schemaName: string) {
     .createTable("ipfs_data")
     .addColumn("cid", "text")
     .addColumn("data", "jsonb")
+    .execute();
+}
+
+export async function migratePriceFetcher<T>(
+  db: Kysely<T>,
+  schemaName: string
+) {
+  const schema = db.withSchema(schemaName).schema;
+
+  await schema
+    .createTable("prices")
+    .addColumn("id", "serial", (cb) => cb.primaryKey())
+    .addColumn("chainId", CHAIN_ID_TYPE)
+    .addColumn("tokenAddress", ADDRESS_TYPE)
+    .addColumn("priceInUSD", "real")
+    .addColumn("timestamp", "timestamptz")
+    .addColumn("blockNumber", BIGINT_TYPE)
+    .execute();
+
+  await db.schema
+    .createIndex("idx_prices_chain_token_block")
+    .on("prices")
+    .expression(sql`chain_id, token_address, block_number DESC`)
     .execute();
 }

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -125,6 +125,11 @@ export type ProjectTable = {
   projectType: ProjectType;
 };
 
+export type IpfsDataTable = {
+  cid: string;
+  data: unknown;
+};
+
 export type Project = Selectable<ProjectTable>;
 export type NewProject = Insertable<ProjectTable>;
 export type PartialProject = Updateable<ProjectTable>;
@@ -253,3 +258,8 @@ export type ApplicationPayout = {
 };
 
 export type NewApplicationPayout = Insertable<ApplicationPayout>;
+
+export type NewIpfsData = {
+  cid: string;
+  data: unknown;
+};

--- a/src/http/api/v1/status.ts
+++ b/src/http/api/v1/status.ts
@@ -9,7 +9,8 @@ export const createHandler = (config: HttpApiConfig): express.Router => {
     res.json({
       hostname: config.hostname,
       buildTag: config.buildTag,
-      databaseSchema: config.db.databaseSchemaName,
+      chainDataSchemaName: config.db.chainDataSchemaName,
+      ipfsDataSchema: config.db.ipfsDataSchemaName,
     });
   });
 

--- a/src/http/api/v1/status.ts
+++ b/src/http/api/v1/status.ts
@@ -11,6 +11,7 @@ export const createHandler = (config: HttpApiConfig): express.Router => {
       buildTag: config.buildTag,
       chainDataSchemaName: config.db.chainDataSchemaName,
       ipfsDataSchema: config.db.ipfsDataSchemaName,
+      priceDataSchema: config.db.priceDataSchemaName,
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,6 +153,7 @@ async function main(): Promise<void> {
     connectionPool: databaseConnectionPool,
     chainDataSchemaName: config.databaseSchemaName,
     ipfsDataSchemaName: config.ipfsDatabaseSchemaName,
+    priceDataSchemaName: config.priceDatabaseSchemaName,
   });
 
   baseLogger.info({
@@ -253,6 +254,9 @@ async function main(): Promise<void> {
         } else if (config.dropIpfsDb) {
           baseLogger.info("resetting ipfs data schema");
           await db.dropIpfsDataSchemaIfExists();
+        } else if (config.dropPriceDb) {
+          baseLogger.info("resetting price data schema");
+          await db.dropPriceDataSchemaIfExists();
         }
 
         await db.createAllSchemas(baseLogger);
@@ -331,7 +335,11 @@ async function main(): Promise<void> {
 
     const graphqlHandler = postgraphile(
       readOnlyDatabaseConnectionPool,
-      config.databaseSchemaName,
+      [
+        config.databaseSchemaName,
+        config.ipfsDatabaseSchemaName,
+        config.priceDatabaseSchemaName,
+      ],
       {
         watchPg: false,
         graphqlRoute: "/graphql",


### PR DESCRIPTION
closes PAR-330

- creates new schema for ipfs
- refactor code to ensure we can connect and use the right schema for the right query 
- have ability to update ipfs and chain data independently
- add --drop-chain-db to drop chain data schema and --drop-ipfs-db to drop ipfs data schema

<img width="1434" alt="Screenshot 2024-09-06 at 1 37 54 AM" src="https://github.com/user-attachments/assets/fc73e98c-d8d8-442d-b267-5c8c6309b585">

<img width="1412" alt="Screenshot 2024-09-06 at 12 29 00 AM" src="https://github.com/user-attachments/assets/f6795b4a-2fdb-4c4f-96ff-2a0157d3af28">


