### PR TITLE
feat: changing URL for downloading the score jsonl data export

### DIFF
--- a/src/passport/index.test.ts
+++ b/src/passport/index.test.ts
@@ -69,7 +69,7 @@ describe("operation", () => {
       await passportProvider.start();
 
       expect(fetchMock).toHaveBeenCalledWith(
-        "https://public.scorer.gitcoin.co/passport_scores/registry_score.jsonl"
+        "https://nyc3.digitaloceanspaces.com/regendata/passport/registry_score.jsonl"
       );
     });
 
@@ -99,7 +99,7 @@ describe("operation", () => {
       await vi.advanceTimersToNextTimerAsync();
 
       expect(fetchMock).toHaveBeenCalledWith(
-        "https://public.scorer.gitcoin.co/passport_scores/registry_score.jsonl"
+        "https://nyc3.digitaloceanspaces.com/regendata/passport/registry_score.jsonl"
       );
 
       fetchMock.mockClear();
@@ -107,7 +107,7 @@ describe("operation", () => {
       await vi.advanceTimersToNextTimerAsync();
 
       expect(fetchMock).toHaveBeenCalledWith(
-        "https://public.scorer.gitcoin.co/passport_scores/registry_score.jsonl"
+        "https://nyc3.digitaloceanspaces.com/regendata/passport/registry_score.jsonl"
       );
     });
   });

--- a/src/passport/index.ts
+++ b/src/passport/index.ts
@@ -199,7 +199,7 @@ export const createPassportProvider = (
 
     const { db } = state;
     const res = await fetch(
-      "https://public.scorer.gitcoin.co/passport_scores/registry_score.jsonl"
+      "https://nyc3.digitaloceanspaces.com/regendata/passport/registry_score.jsonl"
     );
     const { body } = res;
 


### PR DESCRIPTION

This PR contains a change in the URL that is used to pull scoring data by the grants team.
The destination for that data will change, the new URL points to a S3 bucket owned by the grants team.
